### PR TITLE
feat: Async-Iterator interface

### DIFF
--- a/packages/async-iterator/.npmignore
+++ b/packages/async-iterator/.npmignore
@@ -1,0 +1,2 @@
+*.test.js
+CHANGELOG.md

--- a/packages/async-iterator/LICENSE
+++ b/packages/async-iterator/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright 2019 Francis Gulotta. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to
+deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+IN THE SOFTWARE.

--- a/packages/async-iterator/README.md
+++ b/packages/async-iterator/README.md
@@ -1,0 +1,13 @@
+# @serialport/AsyncIterator
+
+This is a node SerialPort project! This package does some neat stuff.
+
+- [Guides and API Docs](https://serialport.io/)
+
+This is why you'd use it.
+
+This is how you use it.
+```js
+const asyncIterator = new AsyncIterator()
+
+```

--- a/packages/async-iterator/lib/async-iterator.js
+++ b/packages/async-iterator/lib/async-iterator.js
@@ -1,0 +1,68 @@
+const DefaultBindings = require('@serialport/bindings')
+const debug = require('debug')('serialport/async-iterator')
+/**
+ * A transform stream that does something pretty cool.
+ * @param {Object} options open options
+ * @example ```
+// To use the `AsyncIterator` interface:
+const { open, list } = require('@serialport/async-iterator')
+const ports = await list()
+const arduinoPort = ports.find(info => (info.manufacture || '').includes('Arduino'))
+const port = await open(arduinoPort)
+
+// read bytes until close
+for await (const bytes of port) {
+  console.log(`read ${bytes.length} bytes`)
+}
+
+// read 12 bytes
+const { value, end } = await port.next(12)
+console.log(`read ${value.length} bytes / port closed: ${end}`)
+
+// write a buffer
+await port.write(Buffer.from('hello!'))
+```
+*/
+
+module.exports.open = async ({ Bindings = DefaultBindings, readSize = 1024, ...openOptions } = {}) => {
+  const port = new Bindings()
+  await port.open(openOptions)
+
+  const next = async (bytesToRead = readSize) => {
+    if (!port.isOpen) {
+      debug('next: port is closed')
+      return { value: undefined, end: true }
+    }
+
+    const readBuffer = Buffer.allocUnsafe(bytesToRead)
+    try {
+      debug(`next: read starting`)
+      const bytesRead = await port.read(readBuffer, 0, bytesToRead)
+      debug(`next: read ${bytesRead} bytes`)
+      const value = readBuffer.slice(0, bytesRead)
+      return { value, end: false }
+    } catch (error) {
+      if (error.canceled) {
+        debug(`next: read canceled`)
+        return { value: undefined, end: true }
+      }
+      debug(`next: read error ${error.message}`)
+      throw error
+    }
+  }
+
+  const asyncIterableIterator = {
+    [Symbol.asyncIterator]: () => asyncIterableIterator,
+    next,
+    write: (data) => port.write(data),
+    close: () => port.close(),
+    update: opt => port.update(opt),
+    set: opt => port.set(opt),
+    get: () => port.get(),
+    flush: () => port.flush(),
+    drain: () => port.drain(),
+  }
+  return asyncIterableIterator
+}
+
+module.exports.DefaultBindings.list

--- a/packages/async-iterator/lib/async-iterator.test.js
+++ b/packages/async-iterator/lib/async-iterator.test.js
@@ -1,0 +1,12 @@
+'use strict'
+/* eslint-disable no-new */
+
+const sinon = require('sinon')
+const AsyncIterator = require('./async-iterator')
+
+describe('AsyncIterator', () => {
+  it('constructs', () => {
+    new AsyncIterator()
+  })
+  it('needs more testing')
+})

--- a/packages/async-iterator/package.json
+++ b/packages/async-iterator/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@serialport/async-iterator",
+  "version": "1.0.0",
+  "main": "lib/async-iterator.js",
+  "dependencies": {
+    "debug": "^4.1.1"
+  },
+  "engines": {
+    "node": ">=10.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/node-serialport/node-serialport.git"
+  }
+}


### PR DESCRIPTION
This is the next generation of serial port interfaces. Streams are never going away but the async iterator interface is much more flexible. It can be combined with async-iterator tools (such as [streaming-iterables](https://www.npmjs.com/package/streaming-iterables)) to make buffers and parsers, and can even be combined with our existing stream based parsers.

This is very experimental. I’ve tried to bring a lot of these changes in https://github.com/node-serialport/node-serialport/tree/reconbot/typescript2 but I haven’t had time for a full typescript rewrite. So maybe this smaller api change lets us get some of these advantages without having to rewrite everything.

## Todo
- [ ] api feedback
- [ ] build chain to support modern javascript
- [ ] docs for website and readme
- [ ] abstract away get/set/update borrowing from https://github.com/node-serialport/node-serialport/issues/1679 for local and remote state and parity with web serial
- [ ] tests

## Example Usage
```js
const { open, list } = require('@serialport/async-iterator')
const ports = await list()
const arduinoPort = ports.find(info => (info.manufacture || '').includes('Arduino'))
const port = await open(arduinoPort)

// read bytes until close
for await (const bytes of port) {
  console.log(`read ${bytes.length} bytes`)
}

// read 12 bytes
const { value, end } = await port.next(12)
console.log(`read ${value.length} bytes / port closed: ${end}`)

// write a buffer
await port.write(Buffer.from('hello!'))
```